### PR TITLE
Add latest GPT 4 Turbo as default option

### DIFF
--- a/models.json
+++ b/models.json
@@ -1,5 +1,8 @@
 {
     "openai": {
+        "gpt-4-0125-preview": {
+            "context_window": 128000
+        },
         "gpt-3.5-turbo": {
             "context_window": 4097
         },


### PR DESCRIPTION
Since I rather want to pay half the price for twice the size, I suggest to add gpt4 turbo as default option.